### PR TITLE
Fix score display in Tetris game

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -171,8 +171,8 @@ function clearLines() {
 function updateScoreDisplay() {
     const scoreElement = document.getElementById("score");
     const linesElement = document.getElementById("lines");
-    if (scoreElement) scoreElement.textContent = `Score: ${score}`;
-    if (linesElement) linesElement.textContent = `Lines: ${lines}`;
+    if (scoreElement) scoreElement.textContent = `${score}`;
+    if (linesElement) linesElement.textContent = `${lines}`;
 }
 
 // Gère la fin du jeu


### PR DESCRIPTION
## Summary
- display raw score and line values in the HUD instead of including labels again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68484214b010833194acc25517a67dd8