### PR TITLE
Fix debug controls and visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,16 +29,37 @@
             <button id="startGame" class="play-button">Play</button>
             <button id="leaderboardButton" class="play-button">Leaderboard</button>
         </div>
+        <div class="debug-toggle">
+            <label><input type="checkbox" id="debugToggle"> Debug Mode</label>
+        </div>
     </div>
+    <div id="debugMessage" class="debug-message">Mode Debug - Dédicace à Ethan</div>
 
     <script>
+        const urlParams = new URLSearchParams(window.location.search);
+        const debugFlag = urlParams.get("debug");
+        const debugToggle = document.getElementById("debugToggle");
+
+        if (debugFlag === "true") {
+            debugToggle.checked = true;
+            document.getElementById("debugMessage").style.display = "block";
+        }
+
+        debugToggle.addEventListener("change", () => {
+            document.getElementById("debugMessage").style.display = debugToggle.checked ? "block" : "none";
+        });
+
         document.getElementById("startGame").addEventListener("click", () => {
             const level = document.getElementById("levelSelect").value;
-            window.location.href = `tetris.html?level=${level}`;
+            const debug = debugToggle.checked ? "true" : (debugFlag || "");
+            const debugQuery = debug ? `&debug=${debug}` : "";
+            window.location.href = `tetris.html?level=${level}${debugQuery}`;
         });
 
         document.getElementById("leaderboardButton").addEventListener("click", () => {
-            window.location.href = `leaderboard.html`;
+            const debug = debugToggle.checked ? "true" : (debugFlag || "");
+            const debugQuery = debug ? `?debug=${debug}` : "";
+            window.location.href = `leaderboard.html${debugQuery}`;
         });
     </script>
 </body>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -29,6 +29,7 @@
             <button id="backButton">Back</button>
         </div>
     </div>
+    <div id="debugMessage" class="debug-message">Mode Debug - Dédicace à Ethan</div>
 
     <script src="leaderboard.js"></script>
 </body>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -2,6 +2,12 @@ document.addEventListener("DOMContentLoaded", () => {
     const leaderboardTable = document.getElementById("leaderboardTable").querySelector("tbody");
     const backButton = document.getElementById("backButton");
     const clearButton = document.getElementById("clearButton");
+    const params = new URLSearchParams(window.location.search);
+    const debugFlag = params.get("debug");
+    if (debugFlag === "true") {
+        const msg = document.getElementById("debugMessage");
+        if (msg) msg.style.display = "block";
+    }
 
     // Charger les scores du local storage
     const scores = JSON.parse(localStorage.getItem("leaderboard")) || [];
@@ -27,7 +33,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Bouton pour revenir au jeu
     backButton.addEventListener("click", () => {
-        window.location.href = "index.html";
+        const debugQuery = debugFlag ? `?debug=${debugFlag}` : "";
+        window.location.href = `index.html${debugQuery}`;
     });
 
     clearButton.addEventListener("click", () => {

--- a/style.css
+++ b/style.css
@@ -95,3 +95,62 @@ button:hover {
     background-color: #fafafa;
     margin-top: 5px;
 }
+
+
+/* Animation de la fusee */
+.rocket {
+    position: fixed;
+    bottom: -50px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 3rem;
+    transition: bottom 3s linear;
+    pointer-events: none;
+    z-index: 9999;
+}
+
+/* Message du mode debug */
+.debug-message {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: 4px;
+    z-index: 1000;
+    display: none;
+}
+
+.debug-toggle {
+    margin-top: 10px;
+    text-align: center;
+}
+
+/* Panneau de debug */
+.debug-panel {
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    display: none;
+    flex-direction: column;
+    gap: 5px;
+    z-index: 1000;
+}
+
+/* Overlay de publicite */
+.ad-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    z-index: 10000;
+}

--- a/tetris.html
+++ b/tetris.html
@@ -25,7 +25,13 @@
                 <canvas class="next" width="80" height="80"></canvas>
             </div>
             <button id="muteButton" class="play-button">Mute</button>
+            <button id="clearLinesButton" class="play-button">Clear 10 Lines</button>
         </div>
+    </div>
+    <div id="debugMessage" class="debug-message">Mode Debug - Dédicace à Ethan</div>
+    <div id="debugPanel" class="debug-panel">
+        <button id="debugTetris" class="play-button">Force Tetris</button>
+        <button id="debugRocket" class="play-button">Rocket</button>
     </div>
     <script src="tetris.js"></script>
 </body>

--- a/tetris.js
+++ b/tetris.js
@@ -1,3 +1,4 @@
+// Gestion complete du Tetris avec mode debug, publicite apres le cheat et fusee a 100000 points
 const canvas = document.getElementById("tetrisCanvas");
 const ctx = canvas.getContext("2d");
 const holdCanvas = document.getElementById("holdCanvas");
@@ -22,6 +23,9 @@ let isPaused = false;
 let muted = false;
 let holdPiece = null;
 let holdUsed = false;
+let rocketShown = false; // track if rocket animation already launched
+let isDebug = false; // debug mode flag
+let lineClearAdUsed = false; // show ad at game over if true
 
 // Musique de fond
 const music = new Audio("theme1.mp3");
@@ -44,6 +48,7 @@ const levelSpeeds = {
 const params = new URLSearchParams(window.location.search);
 const startLevel = parseInt(params.get("level")) || 1;
 dropInterval = levelSpeeds[startLevel] || 1000;
+isDebug = params.get("debug") === "true";
 
 const colors = {
     1: "#FF0D72",
@@ -76,6 +81,22 @@ function initializeGame() {
     const muteButton = document.getElementById("muteButton");
     if (muteButton) {
         muteButton.addEventListener("click", toggleMute);
+    }
+
+    const clearButton = document.getElementById("clearLinesButton");
+    if (clearButton) {
+        clearButton.addEventListener("click", clearLastTenLines);
+    }
+
+    if (isDebug) {
+        const debugMsg = document.getElementById("debugMessage");
+        if (debugMsg) debugMsg.style.display = "block";
+        const panel = document.getElementById("debugPanel");
+        if (panel) panel.style.display = "flex";
+        const dbgTet = document.getElementById("debugTetris");
+        const dbgRkt = document.getElementById("debugRocket");
+        if (dbgTet) dbgTet.addEventListener("click", forceTetris);
+        if (dbgRkt) dbgRkt.addEventListener("click", launchRocket);
     }
 }
 
@@ -189,6 +210,9 @@ function updateScoreDisplay() {
     const linesElement = document.getElementById("lines");
     if (scoreElement) scoreElement.textContent = `${score}`;
     if (linesElement) linesElement.textContent = `${lines}`;
+    if (score >= 100000 && !rocketShown) {
+        launchRocket();
+    }
 }
 
 function saveScore() {
@@ -209,8 +233,15 @@ function saveScore() {
 function gameOver() {
     gameRunning = false;
     music.pause();
-    saveScore();
-    drawGameOverScreen();
+    const proceed = () => {
+        saveScore();
+        drawGameOverScreen();
+    };
+    if (lineClearAdUsed) {
+        showAdvertisement(proceed);
+    } else {
+        proceed();
+    }
 }
 
 // Affiche l'écran de Game Over avec des options
@@ -237,7 +268,8 @@ function handleGameOverInput(e) {
         resetGame();
     } else if (e.key === "m" || e.key === "M") {
         document.removeEventListener("keydown", handleGameOverInput);
-        window.location.href = "index.html"; // Retour au menu principal
+        const debugQuery = isDebug ? "?debug=true" : "";
+        window.location.href = `index.html${debugQuery}`; // Retour au menu principal
     }
 }
 
@@ -248,6 +280,8 @@ function resetGame() {
     board = Array.from({ length: rows }, () => Array(cols).fill(0));
     score = 0;
     lines = 0;
+    rocketShown = false;
+    lineClearAdUsed = false;
     resetPiece();
     update();
     if (!muted) music.play();
@@ -410,10 +444,7 @@ function drawNextPieces() {
         shape.forEach((row, y) => row.forEach((value, x) => {
             if (value) {
                 const color = colors[value];
-                ctx.fillStyle = color;
-                ctx.fillRect(x * grid, y * grid, grid, grid);
-                ctx.strokeStyle = "black";
-                ctx.strokeRect(x * grid, y * grid, grid, grid);
+                drawStyledBlock(ctx, x, y, grid, color);
             }
         }));
     });
@@ -427,20 +458,79 @@ function drawHoldPiece() {
     shape.forEach((row, y) => row.forEach((value, x) => {
         if (value) {
             const color = colors[value];
-            holdCtx.fillStyle = color;
-            holdCtx.fillRect(x * grid, y * grid, grid, grid);
-            holdCtx.strokeStyle = "black";
-            holdCtx.strokeRect(x * grid, y * grid, grid, grid);
+            drawStyledBlock(holdCtx, x, y, grid, color);
         }
     }));
 }
 
-// Dessine un bloc individuel
+// Dessine un bloc individuel avec un leger padding pour un rendu plus fin
 function drawBlock(x, y, color) {
-    ctx.fillStyle = color;
-    ctx.fillRect(x * grid, y * grid, grid, grid);
-    ctx.strokeStyle = "black";
-    ctx.strokeRect(x * grid, y * grid, grid, grid);
+    drawStyledBlock(ctx, x, y, grid, color);
+}
+
+function drawStyledBlock(context, x, y, size, color) {
+    const pad = 2;
+    context.fillStyle = color;
+    context.fillRect(x * size + pad, y * size + pad, size - pad * 2, size - pad * 2);
+    context.strokeStyle = "#555";
+    context.strokeRect(x * size + pad, y * size + pad, size - pad * 2, size - pad * 2);
+}
+
+// Supprime les 10 lignes du bas
+function clearLastTenLines() {
+    if (!gameRunning) return;
+    board.splice(rows - 10, 10);
+    for (let i = 0; i < 10; i++) {
+        board.unshift(Array(cols).fill(0));
+    }
+    lines = Math.max(0, lines - 10);
+    lineClearAdUsed = true;
+    updateScoreDisplay();
+    drawBoard();
+}
+
+// Anime une fusee lorsque le score atteint 100000
+function launchRocket() {
+    rocketShown = true;
+    const rocket = document.createElement('div');
+    rocket.className = 'rocket';
+    rocket.textContent = '🚀';
+    document.body.appendChild(rocket);
+    requestAnimationFrame(() => {
+        rocket.style.bottom = '110%';
+    });
+    setTimeout(() => rocket.remove(), 3000);
+}
+
+// Affiche une publicité pendant une minute puis appelle un callback
+function showAdvertisement(callback) {
+    const overlay = document.createElement('div');
+    overlay.className = 'ad-overlay';
+    const message = document.createElement('div');
+    const countdown = document.createElement('div');
+    overlay.appendChild(message);
+    overlay.appendChild(countdown);
+    document.body.appendChild(overlay);
+    let remaining = 60;
+    const update = () => {
+        message.textContent = 'Publicité...';
+        countdown.textContent = `Reprise dans ${remaining}s`;
+        if (remaining-- <= 0) {
+            clearInterval(timer);
+            overlay.remove();
+            callback();
+        }
+    };
+    update();
+    const timer = setInterval(update, 1000);
+}
+
+// Force la creation d'un Tetris pour le debug
+function forceTetris() {
+    for (let y = rows - 4; y < rows; y++) {
+        board[y] = Array(cols).fill(1);
+    }
+    clearLines();
 }
 
 // Met à jour l'état du jeu
@@ -501,6 +591,19 @@ document.addEventListener("keydown", (e) => {
         case "M":
             toggleMute();
             break;
+        case "l":
+        case "L":
+            clearLastTenLines();
+            break;
+    }
+
+    if (isDebug) {
+        if (e.key === 't' || e.key === 'T') {
+            forceTetris();
+        }
+        if (e.key === 'r' || e.key === 'R') {
+            launchRocket();
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- pass debug option through the menu to game and leaderboard
- show a visible dedication banner when debug mode is enabled
- enable a cheat that clears ten lines and triggers an advertisement at game over
- add a rocket animation once 100000 points are reached
- clarify code with a short comment

## Testing
- `node --check tetris.js`
- `node --check leaderboard.js`


------
https://chatgpt.com/codex/tasks/task_e_685897be77488331a546d645f9d9e51d